### PR TITLE
feat: Trigger status build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: Node.js CI
 
 on:
-  push:
-    branches:
-    - feature/*
-    - bugfix/*
   pull_request:
     branches: 
     - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 name: Node.js CI
 
 on:
+  push:
+    branches:
+    - feature/*
+    - bugfix/*
   pull_request:
     branches: 
-    - $default-branch
+    - main
     - 'release/*'
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ on:
   pull_request:
     branches: 
     - main
-    - 'release/*'
-  workflow_dispatch:
+    - release/*
 
 jobs:
   build:


### PR DESCRIPTION
Changes to make the `ci.yml` workflow result in a build that can be used for branch  [status checks](https://docs.github.com/en/rest/reference/commits#commit-statuses) - the documentation is unclear but the build is not being listed in the branch settings.